### PR TITLE
add smiles to cluster info in FBMN

### DIFF
--- a/feature-based-molecular-networking/tools/feature-based-molecular-networking/scripts/enrich_clusterinfosummary.py
+++ b/feature-based-molecular-networking/tools/feature-based-molecular-networking/scripts/enrich_clusterinfosummary.py
@@ -47,7 +47,7 @@ def main():
     parser.add_argument('params_xml', help='params_xml')
     parser.add_argument('input_clusterinfo_summary', help='Input cluster info summary')
     parser.add_argument('input_network_pairs_file', help='network_pairs_file')
-    parser.add_argument('input_library_search_file', help='network_pairs_file')
+    parser.add_argument('input_library_search_file', help='library_search_file')
     parser.add_argument('output_clusterinfo_summary', help='output file')
     parser.add_argument('output_component_summary', help='output component file')
     args = parser.parse_args()
@@ -72,10 +72,12 @@ def main():
             cluster["LibraryID"] = library_ids_dict[cluster_index]["Compound_Name"]
             cluster["MQScore"] = library_ids_dict[cluster_index]["MQScore"]
             cluster["SpectrumID"] = library_ids_dict[cluster_index]["SpectrumID"]
+            cluster["Smiles"] = library_ids_dict[cluster_index]["Smiles"]
         else:
             cluster["LibraryID"] = "N/A"
             cluster["MQScore"] = "N/A"
             cluster["SpectrumID"] = "N/A"
+            cluster["Smiles"] = "N/A"
 
     ming_fileio_library.write_list_dict_table_data(all_clusterinfo_list, args.output_clusterinfo_summary)
 


### PR DESCRIPTION
This PR adds:
- `Smiles` to cluster summary info file 
-  corrects the input docstring for library identification file 