### PR TITLE
bug fix object name for feature-table group

### DIFF
--- a/qemistree/tools/qemistree/qemistree.py
+++ b/qemistree/tools/qemistree/qemistree.py
@@ -174,7 +174,7 @@ def main():
 
         # Feature Grouping by Metadata
         cmd = f'source {args.conda_activate_bin} {args.conda_environment} && LC_ALL=en_US.UTF-8 && export LC_ALL && qiime feature-table group \
-        --i-table {output_feature_qza} \
+        --i-table {output_merged_feature_table_qza} \
         --m-metadata-column {args.sample_metadata_column} \
         --p-axis sample \
         --m-metadata-file {metadata_files[0]} \


### PR DESCRIPTION
Fixes a bug. 
Previously, it was reading the feature-table QZA from FBMN. We want to read the feature-table QZA from qemistree which has hashed feature IDs