### PR TITLE
remove metadata column option

### DIFF
--- a/qemistree/qemistree/input.xml
+++ b/qemistree/qemistree/input.xml
@@ -47,10 +47,6 @@
             <default value="auto"/>
         </parameter>
 
-        <parameter name="METADATA_COLUMN" label="Sample Metadata Column">
-            <default value="sample_name"/>
-        </parameter>
-
     </parameters>
 
     <!-- Input form layout -->
@@ -134,22 +130,6 @@
 
             <cell>
                 <input type="select" parameter="IONIZATION_MODE">
-                </input>
-            </cell>
-        </row>
-        <row>
-        <cell>
-                <label>
-                    <content parameter="METADATA_COLUMN"/>
-                    <tooltip id="METADATA_COLUMN_gnps_tooltip">
-            Metadata column used to group the samples. We plot the abundance of categories in this column for each molecule on the tree.
-                    </tooltip>
-                </label>
-            </cell>
-
-            <cell>
-                <input type="text" parameter="METADATA_COLUMN">
-                    <attribute name="size" value="30"/>
                 </input>
             </cell>
         </row>

--- a/qemistree/qemistree/result.xml
+++ b/qemistree/qemistree/result.xml
@@ -65,7 +65,7 @@
         <parameter name="URLBASE" value='https://view.qiime2.org/?src=https%3A%2F%2Fcors-anywhere.herokuapp.com%2Fhttps%3A%2F%2Fgnps.ucsd.edu%2FProteoSAFe%2FDownloadResultFile%3Ftask%3D[task]%26file%3Doutput_folder%252Femperor.qzv%26block%3Dmain'/>
     </block>
 
-	<view id="view_qemistree_tree" label="View Qemistree ITOL Tree" group="Advanced Views - qiime2 Views">
+    <view id="view_qemistree_tree" label="View Qemistree ITOL Tree" group="Advanced Views - qiime2 Views">
         <blockRef id="main" type="view_qemistree_tree"/>
     </view>
     <block id="view_qemistree_tree" type="dummylinkout">

--- a/qemistree/qemistree/tool.xml
+++ b/qemistree/qemistree/tool.xml
@@ -30,7 +30,6 @@
             <arg pathRef="sirius.path"/>
             <arg option="-instrument" valueRef="@INSTRUMENT"/>
             <arg option="-ionization_mode" valueRef="@IONIZATION_MODE"/>
-            <arg option="-sample_metadata_column" valueRef="@METADATA_COLUMN"/>
         </execution>
     </tool>
 

--- a/qemistree/tools/qemistree/qemistree.py
+++ b/qemistree/tools/qemistree/qemistree.py
@@ -18,7 +18,6 @@ def main():
     parser.add_argument("conda_environment")
     parser.add_argument("sirius_bin")
     parser.add_argument("--instrument", default="orbitrap")
-    parser.add_argument("--sample_metadata_column", default="sample_name")
     parser.add_argument("--ionization_mode", default="auto")
 
     args = parser.parse_args()
@@ -37,7 +36,6 @@ def main():
     output_fingerprints_qza = os.path.join(args.output_folder, "fingerprints.qza")
     output_qemistree_qza = os.path.join(args.output_folder, "qemistree.qza")
     output_qemistree_pruned_qza = os.path.join(args.output_folder, "qemistree-pruned-smiles.qza")
-    output_qemistree_grouped_table_qza = os.path.join(args.output_folder, "qemistree-grouped-table.qza")
     output_merged_feature_table_qza = os.path.join(args.output_folder, "merged-feature-table.qza")
     output_classified_feature_data_qza = os.path.join(args.output_folder, "classified-feature-data.qza")
     output_merged_data_qza = os.path.join(args.output_folder, "merged-feature-data.qza")
@@ -87,9 +85,8 @@ def main():
 
     input_library_identifications_files = glob.glob(os.path.join(args.input_library_identifications_folder, "*"))
 
-    # TODO: Add in library identifications to be imported, need to write import statement
     if len(input_library_identifications_files) == 1:
-        identifications_qza = os.path.join(args.output_folder, "library_identifications.qza")
+        identifications_qza = os.path.join(args.output_folder, "library-identifications.qza")
         cmd = 'source {} {} && LC_ALL=en_US.UTF-8 && export LC_ALL && qiime tools import \
         --input-path {} \
         --output-path {} \
@@ -174,28 +171,15 @@ def main():
             output_emperor_qza)
         all_cmd.append(cmd)
 
-        # Feature Grouping by Metadata
-        metadata_column = args.sample_metadata_column
-        metadata_column = shlex.quote(metadata_column)
-        cmd = f'source {args.conda_activate_bin} {args.conda_environment} && LC_ALL=en_US.UTF-8 && export LC_ALL && qiime feature-table group \
-        --i-table {output_merged_feature_table_qza} \
-        --m-metadata-column {metadata_column} \
-        --p-axis sample \
-        --m-metadata-file {metadata_files[0]} \
-        --o-grouped-table {output_qemistree_grouped_table_qza} \
-        --p-mode mean-ceiling'
-        all_cmd.append(cmd)
-
-        # Plotting
-        cmd = f'source {args.conda_activate_bin} {args.conda_environment} && LC_ALL=en_US.UTF-8 && export LC_ALL && qiime qemistree plot \
-        --i-tree {output_qemistree_pruned_qza} \
-        --i-feature-metadata {output_classified_feature_data_qza} \
-        --i-grouped-table {output_qemistree_grouped_table_qza} \
-        --p-category direct_parent \
-        --p-ms2-label False \
-        --p-parent-mz True \
-        --o-visualization {output_qemistree_itol_qzv}'
-        all_cmd.append(cmd)
+    # Tree Plotting
+    cmd = f'source {args.conda_activate_bin} {args.conda_environment} && LC_ALL=en_US.UTF-8 && export LC_ALL && qiime qemistree plot \
+    --i-tree {output_qemistree_pruned_qza} \
+    --i-feature-metadata {output_classified_feature_data_qza} \
+    --p-category direct_parent \
+    --p-ms2-label False \
+    --p-parent-mz True \
+    --o-visualization {output_qemistree_itol_qzv}'
+    all_cmd.append(cmd)
 
     #Actually running all the commands
     output_command_log_filename = os.path.join(args.output_folder, "run_log.txt")


### PR DESCRIPTION
This PR:
- gets rid of the metadata column option in the workflow in order to reduce redundancy
- renames library identification file name to match the naming convention with other output files
- updates the tree iTOL link out to plot the tree without bar plots 
  (barplots will be generated using the dashboard)