### PR TITLE
Updating mmvec installation

### DIFF
--- a/mmvec/README.md
+++ b/mmvec/README.md
@@ -3,7 +3,7 @@
 1. wget https://data.qiime2.org/distro/core/qiime2-2019.10-py36-linux-conda.yml
 1. conda env create -n qiime2-2019.10-mmvec --file qiime2-2019.10-py36-linux-conda.yml
 1. conda install -n qiime2-2019.10 pip
-1. Conda activate qiime2-2019.10 
-1. Pip install mmvec==1.0.4
+1. conda activate qiime2-2019.10 
+1. pip install mmvec==1.0.4
 1. qiime dev refresh-cache
 

--- a/mmvec/README.md
+++ b/mmvec/README.md
@@ -2,6 +2,8 @@
 
 1. wget https://data.qiime2.org/distro/core/qiime2-2019.10-py36-linux-conda.yml
 1. conda env create -n qiime2-2019.10-mmvec --file qiime2-2019.10-py36-linux-conda.yml
-1. conda install -n qiime2-2019.10-mmvec mmvec=1.0.4 -c conda-forge
+1. conda install -n qiime2-2019.10 pip
+1. Conda activate qiime2-2019.10 
+1. Pip install mmvec==1.0.4
 1. qiime dev refresh-cache
 


### PR DESCRIPTION
I'm not sure if it is exactly correct the way I suggested in the code... but it worked installing mmvec via pip inside the qiime2 conda environment.
When we install mmvec, it automatically will install tensorflow 1.15.4. It will require to have numpy<1.19.0, >=1.16.0. 
Initially, I had 1.19.4 and I downgraded to numpy==1.18.0.
The mmvec workflow ran successfully, and the lodgir folder was generated.