### PR TITLE
[FBMN] Adding linkout to DEREPLICATOR PLUS and CYCLONOVO

### DIFF
--- a/feature-based-molecular-networking/feature-based-molecular-networking/result.xml
+++ b/feature-based-molecular-networking/feature-based-molecular-networking/result.xml
@@ -524,8 +524,34 @@
             </parsers>
         </data>
     </block>
-
-
+	
+    <view id="dereplicatorplus" label="Analyze with DEREPLICATOR PLUS" group="Advanced Views - Experimental Views">
+        <blockRef id="main" type="dereplicatorplus"/>
+    </view>
+    
+	<block id="dereplicatorplus" type="dummylinkout">
+        <data>
+            <parsers>
+                <parser type="stream" contentType="text/xml"/>
+            </parsers>
+        </data>
+        <parameter name="URLBASE" value='https://gnps.ucsd.edu/ProteoSAFe/index.jsp?params={"workflow":"DEREPLICATOR_PLUS", "desc":"DEREPLICATOR PLUS of FBMN [task]", "spec_on_server":"t.[task]/spectra/specs_ms.mgf"}'/>
+    </block>
+	
+    <view id="cyclonovo" label="Analyze with CYCLONOVO" group="Advanced Views - Experimental Views">
+        <blockRef id="main" type="cyclonovo"/>
+    </view>
+    
+	<block id="cyclonovo" type="dummylinkout">
+        <data>
+            <parsers>
+                <parser type="stream" contentType="text/xml"/>
+            </parsers>
+        </data>
+        <parameter name="URLBASE" value='https://gnps.ucsd.edu/ProteoSAFe/index.jsp?params={"workflow":"CYCLONOVO", "desc":"CYCLONOVO of FBMN [task]", "spec_on_server":"t.[task]/spectra/specs_ms.mgf"}'/>
+    </block>
+	
+	
     <view id="reanalyze_ms2lda" label="Analyze with MS2LDA" group="Advanced Views - Experimental Views">
         <blockRef id="main" type="reanalyze_ms2lda"/>
     </view>


### PR DESCRIPTION
Maybe we should make the link out into a new subsection of results page:
"Advances Annotation Tools"

Currently they are under "Advanced Views - Experimental Views".

If it is just making a new group I can do it for the relevant link out ?  @mwang87 
`<view id="dereplicatorplus" label="Annotate with DEREPLICATOR+" group="Advanced Annotation Tools">`