### PR TITLE
Convert carbon markers RT in minutes to match library spectral library

### DIFF
--- a/molecular-librarysearch-gc/tools/molecularsearch-gc/calculate_kovats.py
+++ b/molecular-librarysearch-gc/tools/molecularsearch-gc/calculate_kovats.py
@@ -8,7 +8,7 @@ def loadMarkers(marker):
 
     # compounds name has to be in the format of "name(C#)"
     df["Compound_Name"] = df["Carbon_Number"].astype('int32')
-    df["RT"] = df["RT"].astype('float32')
+    df["RT"] = df["RT"].astype('float32')/60
     df = df.sort_values(['Compound_Name'], ascending=[True])
 
     return df


### PR DESCRIPTION
The documentation indicates the carbon marker file must be in minutes:
https://ccms-ucsd.github.io/GNPSDocumentation/gc-ms-library-molecular-network/

But the retention index calculation requires retention time in seconds.