### PR TITLE
[MS2LDA] Fixes to work with SSL

### DIFF
--- a/ms2lda_motifdb/tools/ms2lda_motifdb/ms2lda_runfull.py
+++ b/ms2lda_motifdb/tools/ms2lda_motifdb/ms2lda_runfull.py
@@ -22,14 +22,17 @@ def acquire_motifdb(db_list):
             cached_data = json.loads(redis_connection.get(db_list_key))
             return cached_data["motifdb_spectra"], cached_data["motifdb_metadata"], set(cached_data["motifdb_features"])
 
-    client = requests.session()
-    token_output = client.get(server_url + 'initialise_api/', verify=False).json()
-    token = token_output['token']
-    data = {'csrfmiddlewaretoken':token}
+    # no longer needed as CSRF protection has been disabled for get_motifset()
+    # client = requests.session()
+    # token_output = client.get(server_url + 'initialise_api/').json()
+    # token = token_output['token']
+    # data = {'csrfmiddlewaretoken':token}
+
+    data = {}
     data['motifset_id_list'] = db_list
     data['filter'] = 'True'
 
-    output = client.post(server_url + 'get_motifset/',data = data, verify=False).json()
+    output = client.post(server_url + 'get_motifset/',data = data).json()
     motifdb_spectra = output['motifs']
     motifdb_metadata = output['metadata']
     motifdb_features = set()
@@ -191,8 +194,8 @@ args = parser.parse_args()
 
 """Grabbing the latest Motifs from MS2LDA"""
 import requests
-server_url = 'http://ms2lda.org/motifdb/'
-motifset_dict = requests.get(server_url+'list_motifsets/', verify=False).json()
+server_url = 'https://ms2lda.org/motifdb/'
+motifset_dict = requests.get(server_url+'list_motifsets/').json()
 # db_list = ['gnps_binned_005']  # Can update this later with multiple motif sets
 db_list = []
 


### PR DESCRIPTION
Hi Ming,

The GNPS task received empty motifsets when POSTing to ms2lda in this script. This is caused by the redirect from http to https on our end. To fix this, we should POST to https too in this script. Here are some changes I made:

1. Changed http to https.
2. Removed the token thing as it's no longer needed. CSRF protection has been disabled from ms2lda side for the get_motifset method.
3. Should be okay to verify the SSL cert now, so I also removed `verify=False` when making get/post requests.

PS. I still remember our discussion on putting motifdb to a public repo like GitHub. Will get around to doing that someday ...

Thanks,
Joe